### PR TITLE
[FEAT] Article App skeletons

### DIFF
--- a/article/api.go
+++ b/article/api.go
@@ -8,19 +8,17 @@ import (
 
 // test
 // 1. 인스턴스 생성
-// 2. value 하드코딩
+// 2. 하드코딩 제거. ctx에서 body data 불러와서 article로 파싱
 // 3. post to DB
 func create(c *fiber.Ctx) error {
 	db := dataBase.DB()
-	atc := &Article{}
-	atc.Title = "첫 게시글 입니다."
-	atc.Content = "첫 게시글 내용 입니다."
-	atc.CodeNo = "BTC"
-	db.Create(atc)
-	err := c.JSON(&atc)
-	return err
+	article := &Article{}
+	c.BodyParser(article)
+	db.Create(article)
+	return nil
 }
 
+// GET
 func read(c *fiber.Ctx) error {
 	// id, _ := strconv.Atoi(c.Params("post_no"))
 	postNo := c.Params("post_no")
@@ -29,4 +27,23 @@ func read(c *fiber.Ctx) error {
 	db.Find(article, "post_no = ?", postNo)
 	err := c.JSON(*article)
 	return err
+}
+
+// PUT
+func update(c *fiber.Ctx) error {
+	postNo := c.Params("post_no")
+	db := dataBase.DB()
+	article := &Article{}
+	db.Find(article, "post_no = ?", postNo)
+	c.BodyParser(article)
+	db.Save(article)
+	c.JSON(article)
+	return nil
+}
+
+// DELETE
+func delete(c *fiber.Ctx) error {
+	db := dataBase.DB()
+	db.Delete(&Article{}, c.Params("post_no"))
+	return nil
 }

--- a/article/model.go
+++ b/article/model.go
@@ -5,10 +5,12 @@ package article
 // 추후 추가 기능: weather
 type Article struct {
 	PostNo      uint   `gorm:"primaryKey" json:"post_no"`
-	CodeNo      string `json:"code_no"` //연동 게시판 추후 foreign key 적용 예정
+	Code        string `json:"code"`
 	Title       string `json:"title"`
 	Content     string `json:"content"`
 	ReportedCnt uint   `json:"reported_cnt"`
+	VoteUp      uint   `json:"vote_up"`
+	VodeDown    uint   `json:"vote_down"`
 	CreatedAt   int64  `gorm:"autoCreateTime" json:"created_at"`
 	UpdatedAt   int64  `gorm:"autoUpdateTime" json:"updated_at"`
 }

--- a/article/route.go
+++ b/article/route.go
@@ -13,4 +13,6 @@ func (u URL) getURL(path string) string {
 func Routes(app *fiber.App) {
 	app.Get(appName.getURL("/:post_no"), read)
 	app.Post(appName.getURL("/create"), create)
+	app.Put(appName.getURL("/:post_no/update"), update)
+	app.Delete(appName.getURL("/:post_no/delete"), delete)
 }


### PR DESCRIPTION
## :bulb: TODO
- Article Model 설계
## :books: Stack
- gorm
- fiber
## 🏃Process
- [x] API test: Create 하드 코딩 -> json api
- [ ] API test: Update
- [ ] API test: Delete
## Details
ERD 기반 Article 모델 생성
## Results
- CRUD 모두 DB와 정상적으로 기능하는 것을 확인
## TIL
- CreatedAt, UpdatedAt은 gorm이 알아서 관리해주는 듯
## Buggin
- Account 앱과 연동이 되면 CRUD뿐만 아니라 추가 API 로직들이 복잡해질 예정
- 아직은 말그대로 CRUD가 되는지만 구현한 수준