### PR TITLE
[FEAT] Account Model, View(SignUp, Login) 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,4 +45,6 @@
 # database
 *.db
 
+# key
+*.key
 

--- a/account/api.go
+++ b/account/api.go
@@ -1,38 +1,93 @@
 package account
 
 import (
-	dataBase "github.com/YoonBaek/ururu-server/db"
+	"errors"
+	"time"
+
+	dataBase "github.com/YoonBaek/ururu-server/database"
+	"github.com/YoonBaek/ururu-server/key"
 	"github.com/YoonBaek/ururu-server/utils"
 	"github.com/gofiber/fiber/v2"
+	"github.com/golang-jwt/jwt/v4"
+	"github.com/goombaio/namegenerator"
+)
+
+var (
+	errAcountNotExists    error = errors.New("가입되지 않은 이메일이에요")
+	errWrongPw            error = errors.New("비밀번호를 확인해주세요")
+	errEmailAlreadyExists error = errors.New("이미 가입된 이메일입니다")
+	errWrongPwRepeat      error = errors.New("비밀번호 확인이 일치하지 않습니다")
 )
 
 type errorMessage struct {
 	ErrorMessage string `json:"error_message"`
 }
 
-// 회원 가입 로직.
-// 1. 이메일이 중복인지 여부 체크
-// 2. 비밀번호 오기를 방지하기 위해 중복 체크
-// 3. 비밀번호는 암호화해서 서버에 저장
 func signup(c *fiber.Ctx) error {
-	db, usim := dataBase.DB(), UserSignInModel()
-	err := c.BodyParser(usim)
+	signUpModel := UserSignUpModel()
+	err := c.BodyParser(signUpModel)
 	utils.HandleErr(err)
 	// 1.
-	tx := db.Find(&User{}, "email = ?", usim.Email)
-	if tx.RowsAffected > 0 {
-		return c.JSON(&errorMessage{"email already exists"})
+	if isMember(signUpModel.Email) {
+		return c.JSON(&errorMessage{errEmailAlreadyExists.Error()})
 	}
 	// 2.
-	if usim.Password != usim.Repeat {
-		return c.JSON(&errorMessage{"please repeat password correctly"})
+	if signUpModel.Password != signUpModel.Repeat {
+		return c.JSON(&errorMessage{errWrongPwRepeat.Error()})
+	}
+	// 3.
+	auth := &UserAuth{
+		User: User{
+			Email:    signUpModel.Email,
+			Nickname: initRandomNick(),
+		},
+		Password: utils.ToHash(utils.StrToByte(signUpModel.Password)),
 	}
 
-	user := &User{}
-	user.Email = usim.Email
-	// 3.
-	user.Password = utils.ToHash(utils.StrToByte(usim.Password))
+	dataBase.DB().Create(auth)
+	return c.JSON(auth.User)
+}
 
-	db.Create(user)
-	return c.JSON(user)
+func login(c *fiber.Ctx) error {
+	db := dataBase.DB()
+	loginForm := &userLogInModel{}
+	c.BodyParser(loginForm)
+
+	if !isMember(loginForm.Email) {
+		return c.JSON(&errorMessage{errAcountNotExists.Error()})
+	}
+
+	auth := &UserAuth{}
+	db.Joins("User", db.Where(&User{Email: loginForm.Email})).Find(auth)
+	if auth.Password != utils.ToHash(utils.StrToByte(loginForm.Password)) {
+		return c.JSON(&errorMessage{errWrongPw.Error()})
+	}
+
+	expire := time.Now().Add(time.Hour * 120).Unix()
+
+	claims := jwt.MapClaims{
+		"email": auth.User.Email,
+		"name":  auth.User.Nickname,
+		"exp":   expire,
+	}
+	token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+
+	t, err := token.SignedString(key.LoadKey())
+	utils.HandleErr(err)
+
+	return c.JSON(fiber.Map{"token": t})
+}
+
+func isMember(email string) bool {
+	db := dataBase.DB()
+	tx := db.Find(&User{}, "email = ?", email)
+	return tx.RowsAffected > 0
+}
+
+func initRandomNick() string {
+	seed := time.Now().UTC().UnixNano()
+	genName := namegenerator.NewNameGenerator(seed)
+
+	name := genName.Generate()
+	return name
 }

--- a/account/api.go
+++ b/account/api.go
@@ -1,0 +1,38 @@
+package account
+
+import (
+	dataBase "github.com/YoonBaek/ururu-server/db"
+	"github.com/YoonBaek/ururu-server/utils"
+	"github.com/gofiber/fiber/v2"
+)
+
+type errorMessage struct {
+	ErrorMessage string `json:"error_message"`
+}
+
+// 회원 가입 로직.
+// 1. 이메일이 중복인지 여부 체크
+// 2. 비밀번호 오기를 방지하기 위해 중복 체크
+// 3. 비밀번호는 암호화해서 서버에 저장
+func signup(c *fiber.Ctx) error {
+	db, usim := dataBase.DB(), UserSignInModel()
+	err := c.BodyParser(usim)
+	utils.HandleErr(err)
+	// 1.
+	tx := db.Find(&User{}, "email = ?", usim.Email)
+	if tx.RowsAffected > 0 {
+		return c.JSON(&errorMessage{"email already exists"})
+	}
+	// 2.
+	if usim.Password != usim.Repeat {
+		return c.JSON(&errorMessage{"please repeat password correctly"})
+	}
+
+	user := &User{}
+	user.Email = usim.Email
+	// 3.
+	user.Password = utils.ToHash(utils.StrToByte(usim.Password))
+
+	db.Create(user)
+	return c.JSON(user)
+}

--- a/account/model.go
+++ b/account/model.go
@@ -2,13 +2,31 @@ package account
 
 type User struct {
 	UserId     uint   `gorm:"primaryKey" json:"user_id"`
-	Email      string `gorm:"unique;not null"`
-	password   string
-	IsVerified bool  `json:"is_verified"`
-	IsGuru     bool  `json:"is_guru"`
-	IsBlocked  bool  `json:"is_blocked"`
-	Starred    uint  `json:"starred"`
-	Starring   uint  `json:"starring"`
-	JoinedAt   int64 `gorm:"autoCreateTime" json:"joined_at"`
-	LastLogin  int64 `gorm:"autoUpdateTime" json:"last_login"`
+	Email      string `gorm:"unique;not null" json:"email"`
+	Password   string `gorm:"not null" json:"password"`
+	IsVerified bool   `json:"is_verified"`
+	IsGuru     bool   `json:"is_guru"`
+	IsBlocked  bool   `json:"is_blocked"`
+	Starred    uint   `json:"starred"`
+	Starring   uint   `json:"starring"`
+	JoinedAt   int64  `gorm:"autoCreateTime" json:"joined_at"`
+	LastLogin  int64  `gorm:"autoUpdateTime" json:"last_login"`
+}
+
+// 로그인 폼을 따로 받는 이우는....
+// 1. DB에는 암호화된 PW를 집어 넣기 위함
+// 2. 이메일 인증 절차를 거치기 위해서 (추후 구현)
+// 싱글톤패턴을 쓴 이유는 별건 없고 디폴트 값 설정을 위해서...
+// 추후 이메일 검증 로직을 추가할 예정
+type userSignInModel struct {
+	Email    string `json:"email"`
+	Password string `json:"password"`
+	Repeat   string `json:"repeat"`
+	// IsEmailVerified bool   `json:"is_email_verified"` // tmp
+}
+
+func UserSignInModel() *userSignInModel {
+	u := &userSignInModel{}
+	// u.IsEmailVerified = true
+	return u
 }

--- a/account/model.go
+++ b/account/model.go
@@ -3,7 +3,7 @@ package account
 type User struct {
 	UserId     uint   `gorm:"primaryKey" json:"user_id"`
 	Email      string `gorm:"unique;not null" json:"email"`
-	Password   string `gorm:"not null" json:"password"`
+	Nickname   string `gorm:"unique;not null" json:"nickname"`
 	IsVerified bool   `json:"is_verified"`
 	IsGuru     bool   `json:"is_guru"`
 	IsBlocked  bool   `json:"is_blocked"`
@@ -13,20 +13,31 @@ type User struct {
 	LastLogin  int64  `gorm:"autoUpdateTime" json:"last_login"`
 }
 
+type UserAuth struct {
+	User     User `gorm:"primaryKey;foreignkey:UserId;constraint:OnDelete:CASCADE;refereces:UserId"`
+	UserId   uint
+	Password string `gorm:"not null" json:"password"`
+}
+
 // 로그인 폼을 따로 받는 이우는....
 // 1. DB에는 암호화된 PW를 집어 넣기 위함
 // 2. 이메일 인증 절차를 거치기 위해서 (추후 구현)
 // 싱글톤패턴을 쓴 이유는 별건 없고 디폴트 값 설정을 위해서...
 // 추후 이메일 검증 로직을 추가할 예정
-type userSignInModel struct {
+type userSignUpModel struct {
 	Email    string `json:"email"`
 	Password string `json:"password"`
 	Repeat   string `json:"repeat"`
 	// IsEmailVerified bool   `json:"is_email_verified"` // tmp
 }
 
-func UserSignInModel() *userSignInModel {
-	u := &userSignInModel{}
+func UserSignUpModel() *userSignUpModel {
+	u := &userSignUpModel{}
 	// u.IsEmailVerified = true
 	return u
+}
+
+type userLogInModel struct {
+	Email    string `json:"email"`
+	Password string `json:"password"`
 }

--- a/account/route.go
+++ b/account/route.go
@@ -12,4 +12,5 @@ func (u URL) getURL(path string) string {
 
 func Routes(app *fiber.App) {
 	app.Post(appName.getURL("/signup"), signup)
+	app.Post(appName.getURL("/login"), login)
 }

--- a/account/route.go
+++ b/account/route.go
@@ -1,0 +1,15 @@
+package account
+
+import "github.com/gofiber/fiber/v2"
+
+const appName URL = "/account"
+
+type URL string
+
+func (u URL) getURL(path string) string {
+	return string(u) + path
+}
+
+func Routes(app *fiber.App) {
+	app.Post(appName.getURL("/signup"), signup)
+}

--- a/article/api.go
+++ b/article/api.go
@@ -1,7 +1,7 @@
 package article
 
 import (
-	dataBase "github.com/YoonBaek/ururu-server/db"
+	dataBase "github.com/YoonBaek/ururu-server/database"
 
 	"github.com/gofiber/fiber/v2"
 )

--- a/database/db.go
+++ b/database/db.go
@@ -20,7 +20,7 @@ func DB() *gorm.DB {
 func InitDataBase() {
 	db, err = gorm.Open(sqlite.Open("ururu.db"))
 	utils.HandleErr(err)
-	fmt.Println("------------------------")
-	fmt.Println("database init suceed")
-	fmt.Println("------------------------")
+	fmt.Println("--------------------------")
+	fmt.Println("   database init suceed   ")
+	fmt.Println("--------------------------")
 }

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,9 @@ module github.com/YoonBaek/ururu-server
 go 1.17
 
 require (
-	github.com/gofiber/fiber/v2 v2.23.0
+	github.com/gofiber/fiber/v2 v2.24.0
+	github.com/golang-jwt/jwt/v4 v4.2.0
+	github.com/goombaio/namegenerator v0.0.0-20181006234301-989e774b106e
 	gorm.io/driver/sqlite v1.2.6
 	gorm.io/gorm v1.22.4
 )

--- a/go.sum
+++ b/go.sum
@@ -4,9 +4,13 @@ github.com/andybalholm/brotli v1.0.4/go.mod h1:fO7iG3H7G2nSZ7m0zPUDn85XEX2GTukHG
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/gofiber/fiber/v2 v2.23.0 h1:kcJGMC6SULJ2G7p7mbs+A28cVLOeJSR694jfGyGZqRI=
-github.com/gofiber/fiber/v2 v2.23.0/go.mod h1:MR1usVH3JHYRyQwMe2eZXRSZHRX38fkV+A7CPB+DlDQ=
+github.com/gofiber/fiber/v2 v2.24.0 h1:18rpLoQMJBVlLtX/PwgHj3hIxPSeWfN1YeDJ2lEnzjU=
+github.com/gofiber/fiber/v2 v2.24.0/go.mod h1:MR1usVH3JHYRyQwMe2eZXRSZHRX38fkV+A7CPB+DlDQ=
+github.com/golang-jwt/jwt/v4 v4.2.0 h1:besgBTC8w8HjP6NzQdxwKH9Z5oQMZ24ThTrHp3cZ8eU=
+github.com/golang-jwt/jwt/v4 v4.2.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
 github.com/golang/snappy v0.0.3/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
+github.com/goombaio/namegenerator v0.0.0-20181006234301-989e774b106e h1:XmA6L9IPRdUr28a+SK/oMchGgQy159wvzXA5tJ7l+40=
+github.com/goombaio/namegenerator v0.0.0-20181006234301-989e774b106e/go.mod h1:AFIo+02s+12CEg8Gzz9kzhCbmbq6JcKNrhHffCGA9z4=
 github.com/jinzhu/inflection v1.0.0 h1:K317FqzuhWc8YvSVlFMCCUb36O/S9MCKRDI7QkRKD/E=
 github.com/jinzhu/inflection v1.0.0/go.mod h1:h+uFLlag+Qp1Va5pdKtLDYj+kHp5pxUVkryuEj+Srlc=
 github.com/jinzhu/now v1.1.2/go.mod h1:d3SSVoowX0Lcu0IBviAWJpolVfI5UJVZZ7cO71lE/z8=

--- a/key/key.go
+++ b/key/key.go
@@ -1,0 +1,36 @@
+package key
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"os"
+
+	"github.com/YoonBaek/ururu-server/utils"
+)
+
+const keyFileName string = "secret.key"
+
+var (
+	serverKey *rsa.PrivateKey
+)
+
+func GenerateKey() {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	utils.HandleErr(err)
+	saveKey(key)
+}
+
+func saveKey(key *rsa.PrivateKey) {
+	bytes := x509.MarshalPKCS1PrivateKey(key)
+	err := os.WriteFile(keyFileName, bytes, 0644)
+	utils.HandleErr(err)
+}
+
+func LoadKey() *rsa.PrivateKey {
+	keyAsBytes, err := os.ReadFile(keyFileName)
+	utils.HandleErr(err)
+	serverKey, err = x509.ParsePKCS1PrivateKey(keyAsBytes)
+	utils.HandleErr(err)
+	return serverKey
+}

--- a/migration/migration.go
+++ b/migration/migration.go
@@ -5,13 +5,14 @@ import (
 
 	"github.com/YoonBaek/ururu-server/account"
 	"github.com/YoonBaek/ururu-server/article"
-	dataBase "github.com/YoonBaek/ururu-server/db"
+	dataBase "github.com/YoonBaek/ururu-server/database"
 )
 
 func MakeMigrations() {
 	dataBase.DB().AutoMigrate(
 		&article.Article{},
 		&account.User{},
+		&account.UserAuth{},
 	)
 	fmt.Println("data migrations done")
 }

--- a/server.go
+++ b/server.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"github.com/YoonBaek/ururu-server/account"
 	"github.com/YoonBaek/ururu-server/article"
 	dataBase "github.com/YoonBaek/ururu-server/db"
 	"github.com/YoonBaek/ururu-server/migration"
@@ -15,5 +16,6 @@ func init() {
 func main() {
 	app := fiber.New()
 	article.Routes(app)
+	account.Routes(app)
 	app.Listen(":3000")
 }

--- a/server.go
+++ b/server.go
@@ -3,12 +3,14 @@ package main
 import (
 	"github.com/YoonBaek/ururu-server/account"
 	"github.com/YoonBaek/ururu-server/article"
-	dataBase "github.com/YoonBaek/ururu-server/db"
+	dataBase "github.com/YoonBaek/ururu-server/database"
+	"github.com/YoonBaek/ururu-server/key"
 	"github.com/YoonBaek/ururu-server/migration"
 	"github.com/gofiber/fiber/v2"
 )
 
 func init() {
+	key.GenerateKey()
 	dataBase.InitDataBase()
 	migration.MakeMigrations()
 }
@@ -18,4 +20,5 @@ func main() {
 	article.Routes(app)
 	account.Routes(app)
 	app.Listen(":3000")
+
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -1,8 +1,12 @@
 package utils
 
-import "log"
+import (
+	"crypto/sha256"
+	"fmt"
+	"log"
+)
 
-func ToByte(message string) []byte {
+func StrToByte(message string) []byte {
 	return []byte(message)
 }
 
@@ -10,4 +14,9 @@ func HandleErr(err error) {
 	if err != nil {
 		log.Panicln(err)
 	}
+}
+
+func ToHash(bytes []byte) string {
+	crypted := sha256.Sum256(bytes)
+	return fmt.Sprintf("%x", crypted)
 }


### PR DESCRIPTION
## :bulb: TODO
- Account 앱 기본 기능 구현
## 🏃Process
- [x] 회원가입 구현
- [x] 로그인 구현
- [ ] 로그아웃 구현
## Details 
- Article의 author와도 연동하기
## Recap
### SignUp 기능 구현 명세
v1. 
유저모델을 직접 불러와 email 등록 유무 확인. 암호 입력 일치한지 확인 후 PW 해싱 후 저장하는 단순하고 간단한 로직 구현
v2.
리팩토링 후 로그인 모델에 변동을 줌.
1. POST 요청을 처리할 때 json api 수신 payload를 줄이기 위해 sign up, log in 모델을 따로 생성
2. db 직접 체크 -> 이메일 입력 후 디비 존재 유무체크하는 `isMember()` 함수로 리팩토링
3. User 모델은 서비스 운영시 Back단에서 호출될 일이 많을 거 같아 Password는 `UserAuth`라는 자식 테이블로 따로 빼서 처리
```
	auth := &UserAuth{
		User: User{
			Email:    signUpModel.Email,
			Nickname: initRandomNick(),
		},
		Password: utils.ToHash(utils.StrToByte(signUpModel.Password)),
	}
```
위와 같은 코드를 통해 연결된 두 테이블에 한꺼번에 데이터를 넣을 수 있어서 좋았음.
User 모델을 임베드한 UserAuth 모델을 저장하면 자동으로 User 모델도 DB에 등록
### LogIn 기능 구현 명세
로그인에 필요한 요소는 두가지. 첫번째는 이메일, 두번째는 비밀번호
로그인 명세는 기능 흐름대로 작성
1. 로그인 폼을 통해 POST 요청으로 들어온 json api를 모델로 변환
2. 만약 회원이 아니라면, 에러를 반환하고 종료
3. 로그인 폼에서 들어온 이메일을 바탕으로 DB 비밀번호와 입력 비밀번호를 대조
4. 일치하지 않으면 에러를 반환하고 종료
5. 비밀번호까지 일치하면 json 토큰을 클라이언트에게 전달
### Key 패키지 새로 생성
login 구현을 위해 필요했고, 생각보다 공부할 게 많았음
JWT를 사용하기 위해 go-jwt를 적용
서버용 암호를 저장해 놓고 대조시 load 함수를 통해 활용
key 적용 알고리즘: RSA
로컬에 비공개 키를 저장, jwt 서명까지 구현 완료
## TODO
1. 로그아웃 기능
2. JWT 검증 기능
3. account api들 싹 다 리팩토링. 시맨틱하지 않고 길기만 함
4. 회원 가입 시 email verify 해야 함
5. 또 생각나는대로 추가